### PR TITLE
Upgrade Scala dependencies and modernize simple math app

### DIFF
--- a/05-simple-math/scala-simple-math/build.sbt
+++ b/05-simple-math/scala-simple-math/build.sbt
@@ -2,9 +2,9 @@ name := "simple-math"
 
 version := "1.1.0"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.12"
 
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-effect" % "1.3.1",
-  "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+  "org.typelevel" %% "cats-effect" % "3.5.4",
+  "org.scalatest" %% "scalatest" % "3.2.18" % Test
 )

--- a/05-simple-math/scala-simple-math/project/build.properties
+++ b/05-simple-math/scala-simple-math/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.9.9

--- a/05-simple-math/scala-simple-math/project/plugins.sbt
+++ b/05-simple-math/scala-simple-math/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")

--- a/05-simple-math/scala-simple-math/src/main/scala/com/lochnesh/exercises/simplemath/ComputationImplicits.scala
+++ b/05-simple-math/scala-simple-math/src/main/scala/com/lochnesh/exercises/simplemath/ComputationImplicits.scala
@@ -1,19 +1,27 @@
 package com.lochnesh.exercises.simplemath
 
-import scala.language.implicitConversions
-
 object ComputationImplicits {
-  implicit class ComputationConverter[T](x: T)(implicit n: Numeric[T]) {
+  implicit class ComputationConverter[T](private val value: T)(implicit n: Numeric[T]) {
 
-    def plus(s: BigDecimal): BigDecimal = convert(x,n) + s
+    def plus(other: BigDecimal): BigDecimal = convert(value) + other
 
-    def minus(s: BigDecimal): BigDecimal = convert(x,n) - s
+    def minus(other: BigDecimal): BigDecimal = convert(value) - other
 
-    def times(s: BigDecimal): BigDecimal = convert(x,n) * s
+    def times(other: BigDecimal): BigDecimal = convert(value) * other
 
-    def divide(s: BigDecimal): BigDecimal = convert(x,n) / s
+    def divide(other: BigDecimal): BigDecimal = convert(value) / other
 
-    private def convert(x:T, n: Numeric[T]) = BigDecimal(n.toDouble(x))
+    private def convert(x: T): BigDecimal = x match {
+      case bd: BigDecimal ⇒ bd
+      case bi: BigInt     ⇒ BigDecimal(bi)
+      case l: Long        ⇒ BigDecimal(l)
+      case i: Int         ⇒ BigDecimal(i)
+      case s: Short       ⇒ BigDecimal(s.toInt)
+      case b: Byte        ⇒ BigDecimal(b.toInt)
+      case f: Float       ⇒ BigDecimal.decimal(f.toDouble)
+      case d: Double      ⇒ BigDecimal.decimal(d)
+      case other          ⇒ BigDecimal(other.toString)
+    }
 
   }
 }

--- a/05-simple-math/scala-simple-math/src/main/scala/com/lochnesh/exercises/simplemath/Main.scala
+++ b/05-simple-math/scala-simple-math/src/main/scala/com/lochnesh/exercises/simplemath/Main.scala
@@ -1,22 +1,25 @@
 package com.lochnesh.exercises.simplemath
 
+import cats.effect.{IO, IOApp}
 import com.lochnesh.exercises.simplemath.ComputationImplicits._
-import scala.io.StdIn._
-import cats.effect.IO
 
-object Main extends App {
+import scala.io.StdIn.readLine
 
-  def read(prompt: String) = IO { BigDecimal(readLine(prompt)) }
-  def print(output: String) = IO { println(output) }
+object Main extends IOApp.Simple {
 
-  val program = for {
+  private def read(prompt: String): IO[BigDecimal] =
+    IO.blocking(BigDecimal(readLine(prompt)))
+
+  private def write(output: String): IO[Unit] = IO.blocking(println(output))
+
+  private val program: IO[Unit] = for {
     x ← read("What is the first number? ")
     y ← read("What is the second number? ")
-    _ ← print(s"$x + $y = ${x plus y}")
-    _ ← print(s"$x - $y = ${x minus y}")
-    _ ← print(s"$x * $y = ${x times y}")
-    _ ← print(s"$x / $y = ${x divide y}")
+    _ ← write(s"$x + $y = ${x plus y}")
+    _ ← write(s"$x - $y = ${x minus y}")
+    _ ← write(s"$x * $y = ${x times y}")
+    _ ← write(s"$x / $y = ${x divide y}")
   } yield ()
 
-  program.unsafeRunSync()
+  override def run: IO[Unit] = program
 }

--- a/05-simple-math/scala-simple-math/src/test/scala/com/lochnesh/exercises/simplemath/ComputationsSpec.scala
+++ b/05-simple-math/scala-simple-math/src/test/scala/com/lochnesh/exercises/simplemath/ComputationsSpec.scala
@@ -1,33 +1,34 @@
 package com.lochnesh.exercises.simplemath
 
-import org.scalatest.{Matchers, FlatSpec}
 import com.lochnesh.exercises.simplemath.ComputationImplicits._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ComputationsSpec extends FlatSpec with Matchers {
+class ComputationsSpec extends AnyFlatSpec with Matchers {
 
   // scalastyle:off magic.number
   "Addition" should "return numbers added together" in {
-    1 plus 2 should be (3)
-    2 plus 3 should be (5)
-    1.2 plus .2 should be (1.4)
+    1 plus 2 shouldBe BigDecimal(3)
+    2 plus 3 shouldBe BigDecimal(5)
+    1.2 plus .2 shouldBe BigDecimal("1.4")
   }
 
   "Subtraction" should "return number1 minus number2" in {
-    2 minus 1 should be(1)
-    5 minus 1 should be (4)
-    1.1 minus .9 should be (.2)
+    2 minus 1 shouldBe BigDecimal(1)
+    5 minus 1 shouldBe BigDecimal(4)
+    1.1 minus .9 shouldBe BigDecimal("0.2")
   }
 
   "Multiplication" should "return number1 times number2" in {
-    2 times 3 should be (6)
-    2 times 7 should be (14)
-    1.1 times .2 should be (.22)
+    2 times 3 shouldBe BigDecimal(6)
+    2 times 7 shouldBe BigDecimal(14)
+    1.1 times .2 shouldBe BigDecimal("0.22")
   }
 
   "Division" should "return number1 divided by number2" in {
-    8 divide 2 should be (4)
-    12 divide 4 should be (3)
-    1.5 divide .2 should be (7.5)
+    8 divide 2 shouldBe BigDecimal(4)
+    12 divide 4 shouldBe BigDecimal(3)
+    1.5 divide .2 shouldBe BigDecimal("7.5")
   }
   // scalastyle:on magic.number
 

--- a/05-simple-math/scala-simple-math/src/test/scala/com/lochnesh/exercises/simplemath/MainSpec.scala
+++ b/05-simple-math/scala-simple-math/src/test/scala/com/lochnesh/exercises/simplemath/MainSpec.scala
@@ -3,16 +3,17 @@ package com.lochnesh.exercises.simplemath
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import com.lochnesh.exercises.simplemath.ComputationImplicits._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MainSpec extends FlatSpec with Matchers {
+class MainSpec extends AnyFlatSpec with Matchers {
 
   def capture(inputs: Any*)(func: () ⇒ Unit): Seq[String] = {
     val outputStream = new ByteArrayOutputStream()
     Console.withIn(new ByteArrayInputStream(inputs.mkString("\n").getBytes()))(
       Console.withOut(outputStream)(func())
     )
-    outputStream.toString().split("\n")
+    outputStream.toString().split("\n").toSeq
   }
 
   "Run" should "read two inputs and print some computations" in {

--- a/features/05_simple_math.feature
+++ b/features/05_simple_math.feature
@@ -1,14 +1,14 @@
 Feature: 05 Simple math
  Scenario: Scala
-     When I run `java -jar ../../05-simple-math/scala-simple-math/target/scala-2.12/simple-math-assembly-1.1.0.jar` interactively
+     When I run `java -jar ../../05-simple-math/scala-simple-math/target/scala-2.13/simple-math-assembly-1.1.0.jar` interactively
      And I type "10"
      And I type "5"
      Then the output should contain "What is the first number? "
      And the output should contain "What is the second number? "
      And the output should contain:
          """
-         10 + 5 = 15.0
-         10 - 5 = 5.0
-         10 * 5 = 50.0
-         10 / 5 = 2.0
+         10 + 5 = 15
+         10 - 5 = 5
+         10 * 5 = 50
+         10 / 5 = 2
          """


### PR DESCRIPTION
## Summary
- upgrade the project to Scala 2.13.12 together with cats-effect 3.5.4 and ScalaTest 3.2.18
- migrate the main program onto cats-effect IOApp.Simple and tighten numeric conversions
- refresh the ScalaTest suites for the 3.2 style and adjust console capture for Scala 2.13 collections

## Testing
- ../../../sbt/bin/sbt test

------
https://chatgpt.com/codex/tasks/task_b_68cd6f20297883219f8f472f2bb55c4a