### PR TITLE
Adjust verify script for Python 3 pizza party tests

### DIFF
--- a/08-pizza-party/python-pizza-party/README.md
+++ b/08-pizza-party/python-pizza-party/README.md
@@ -3,11 +3,11 @@
 ##to run
 
 ```
-./main.py
+python3 main.py
 ```
 
 ##tests
 
 ```
-python -m unittest discover -s tests
+python3 -m unittest discover -s tests
 ```

--- a/08-pizza-party/python-pizza-party/main.py
+++ b/08-pizza-party/python-pizza-party/main.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 from party import PizzaParty
 
 
@@ -18,4 +17,4 @@ def run(read, prt):
     prt('There are %s leftover pieces.' % (party.leftovers()))
 
 if __name__ == "__main__":
-    run(raw_input, print)
+    run(input, print)

--- a/08-pizza-party/python-pizza-party/party/__init__.py
+++ b/08-pizza-party/python-pizza-party/party/__init__.py
@@ -1,1 +1,1 @@
-from party import PizzaParty # noqa F401
+from .party import PizzaParty  # noqa: F401

--- a/08-pizza-party/python-pizza-party/party/party.py
+++ b/08-pizza-party/python-pizza-party/party/party.py
@@ -20,7 +20,7 @@ class PizzaParty():
         return self
 
     def pieces_per_person(self):
-        return self.slices / self.people
+        return self.slices // self.people
 
     def leftovers(self):
         return self.slices % self.people

--- a/verify.sh
+++ b/verify.sh
@@ -13,6 +13,11 @@ verify_python()
   python -m unittest discover -s tests
 }
 
+verify_python3()
+{
+  python3 -m unittest discover -s tests
+}
+
 verify_scala()
 {
   sbt scalastyle test:scalastyle assembly
@@ -40,7 +45,7 @@ pushd 06-retirement-calculator/elixir_retirement_calculator && verify_elixir && 
 pushd 07-area-of-room/elixir_area_of_room && verify_elixir && popd
 
 #08
-pushd 08-pizza-party/python-pizza-party && verify_python && popd
+pushd 08-pizza-party/python-pizza-party && verify_python3 && popd
 
 #09
 pushd 09-paint-calculator/scala-paint-calculator && verify_scala && popd


### PR DESCRIPTION
## Summary
- add a dedicated `verify_python3` helper in the root verify script
- run the pizza party checks with Python 3 while leaving other Python projects on the original runner

## Testing
- python3 -m unittest discover -s tests (from 08-pizza-party/python-pizza-party)


------
https://chatgpt.com/codex/tasks/task_b_68d4b3871750832191f09fe4b4af20f6