### PR TITLE
Fix Scala 3 compatibility in paint calculator

### DIFF
--- a/09-paint-calculator/scala-paint-calculator/build.sbt
+++ b/09-paint-calculator/scala-paint-calculator/build.sbt
@@ -2,9 +2,9 @@ name := "paint-calculator"
 
 version := "1.1.0"
 
-scalaVersion := "2.12.8"
+scalaVersion := "3.7.3"
 
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-effect" % "1.3.1",
-  "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+  "org.typelevel" %% "cats-effect" % "3.6.3",
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test
 )

--- a/09-paint-calculator/scala-paint-calculator/project/build.properties
+++ b/09-paint-calculator/scala-paint-calculator/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.10.5

--- a/09-paint-calculator/scala-paint-calculator/project/plugins.sbt
+++ b/09-paint-calculator/scala-paint-calculator/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")

--- a/09-paint-calculator/scala-paint-calculator/src/main/scala/com/lochnesh/paint/calculator/Main.scala
+++ b/09-paint-calculator/scala-paint-calculator/src/main/scala/com/lochnesh/paint/calculator/Main.scala
@@ -1,19 +1,20 @@
 package com.lochnesh.paint.calculator
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 
 object Main extends App {
-  val input = (prompt: String) ⇒ scala.io.StdIn.readLine(prompt)
+  val input = (prompt: String) => scala.io.StdIn.readLine(prompt)
   PaintCalculator.run(input, println)
 }
 
 object PaintCalculator {
-  def run(input: (String) ⇒ String, output: (String) ⇒ Unit): Unit = {
+  def run(input: String => String, output: String => Unit): Unit = {
     val program = for {
-      length ← IO { input("What is the length of the ceiling? ").toDouble }
-      width ← IO { input("What is the width of the ceiling? ").toDouble }
+      length <- IO { input("What is the length of the ceiling? ").toDouble }
+      width <- IO { input("What is the width of the ceiling? ").toDouble }
       gallons = Calculator.gallons(length, width)
-      _ ← IO { output(s"You will need $gallons gallon${if (gallons > 1) "s" else ""} of paint to cover ${length * width} square feet.") }
+      _ <- IO { output(s"You will need $gallons gallon${if (gallons > 1) "s" else ""} of paint to cover ${length * width} square feet.") }
     } yield ()
 
     program.unsafeRunSync()

--- a/09-paint-calculator/scala-paint-calculator/src/test/scala/com/lochnesh/paint/calculator/CalculatorSpec.scala
+++ b/09-paint-calculator/scala-paint-calculator/src/test/scala/com/lochnesh/paint/calculator/CalculatorSpec.scala
@@ -1,14 +1,15 @@
 package com.lochnesh.paint.calculator
 
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CalculatorSpec extends FlatSpec with Matchers {
+class CalculatorSpec extends AnyFlatSpec with Matchers {
 
   // scalastyle:off magic.number
   it should "calculate number of gallons needed for a surface" in {
-    Calculator.gallons(10, 5) should be (1)
-    Calculator.gallons(70, 5) should be (1)
-    Calculator.gallons(20, 18) should be (2)
+    Calculator.gallons(10, 5) shouldBe 1
+    Calculator.gallons(70, 5) shouldBe 1
+    Calculator.gallons(20, 18) shouldBe 2
   }
   // scalastyle:on magic.number
 }

--- a/09-paint-calculator/scala-paint-calculator/src/test/scala/com/lochnesh/paint/calculator/MainSpec.scala
+++ b/09-paint-calculator/scala-paint-calculator/src/test/scala/com/lochnesh/paint/calculator/MainSpec.scala
@@ -1,7 +1,9 @@
 package com.lochnesh.paint.calculator
 
-import org.scalatest.{AsyncFlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Promise
 
 class MainSpec extends AsyncFlatSpec with Matchers {
@@ -11,7 +13,7 @@ class MainSpec extends AsyncFlatSpec with Matchers {
 
     PaintCalculator.run(inputs("12", "10"), func)
 
-    result.future map { _ should be ("You will need 1 gallon of paint to cover 120.0 square feet.") }
+    result.future.map { _ shouldBe "You will need 1 gallon of paint to cover 120.0 square feet." }
   }
 
   it should "pluralize response" in {
@@ -19,21 +21,21 @@ class MainSpec extends AsyncFlatSpec with Matchers {
 
     PaintCalculator.run(inputs("20", "30"), func)
 
-    result.future map { _ should be ("You will need 2 gallons of paint to cover 600.0 square feet.") }
+    result.future.map { _ shouldBe "You will need 2 gallons of paint to cover 600.0 square feet." }
   }
 
   private def inputs(length: String, width: String) = {
-    (p: String) ⇒ {
+    (p: String) => {
       p match {
-        case "What is the length of the ceiling? " ⇒ length
-        case "What is the width of the ceiling? " ⇒ width
+        case "What is the length of the ceiling? " => length
+        case "What is the width of the ceiling? " => width
       }
     }
   }
 
   private def output() = {
     val data = Promise[String]()
-    val output: (String) ⇒ Unit = (t: String) ⇒ {
+    val output: String => Unit = (t: String) => {
       data.success(t)
     }
     (data, output)


### PR DESCRIPTION
## Summary
- add the cats-effect runtime import and replace deprecated Unicode syntax so the paint calculator runs on Scala 3
- migrate ScalaTest specs to AnyFlatSpec/AsyncFlatSpec with modern matcher syntax
- update the sbt-assembly plugin to 2.2.0 so sbt 1.10.5 can resolve build plugins

## Testing
- `/tmp/sbt/bin/sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68d4b3492710832199f0d0ba760a6e9e