### PR TITLE
Update Ruby dependencies for Cucumber suite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,51 @@
 FROM lochnesh/exercises-docker:latest
+
 MAINTAINER Skyler Nesheim
+
+ENV RUBY_VERSION=3.4.4
 
 RUN set -eux; \
     apk add --no-cache \
         python3 \
-        build-base \
         curl \
         git \
+        ca-certificates \
+        gdbm \
+        libffi \
+        libxml2 \
+        libxslt \
+        libyaml \
+        ncurses \
+        openssl \
+        readline \
+        zlib; \
+    apk add --no-cache --virtual .ruby-builddeps \
+        autoconf \
+        bison \
+        build-base \
+        bzip2 \
+        bzip2-dev \
+        gdbm-dev \
         libffi-dev \
+        libxml2-dev \
+        libxslt-dev \
+        libyaml-dev \
+        linux-headers \
+        ncurses-dev \
         openssl-dev \
         readline-dev \
-        yaml-dev \
-        zlib-dev \
-        ruby \
-        ruby-dev; \
+        zlib-dev; \
+    curl -fsSLO "https://cache.ruby-lang.org/pub/ruby/${RUBY_VERSION%.*}/ruby-${RUBY_VERSION}.tar.gz"; \
+    tar -xzf ruby-${RUBY_VERSION}.tar.gz; \
+    cd ruby-${RUBY_VERSION}; \
+    ./configure --disable-install-doc; \
+    make -j "$(nproc)"; \
+    make install; \
+    cd /; \
+    rm -rf ruby-${RUBY_VERSION} ruby-${RUBY_VERSION}.tar.gz; \
     gem update --system --no-document; \
-    gem install --no-document bundler:2.6.7
+    gem install --no-document bundler:2.6.7; \
+    apk del .ruby-builddeps
 
 COPY ./ /usr/src/exercises
 WORKDIR /usr/src/exercises

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM lochnesh/exercises-docker:latest
 MAINTAINER Skyler Nesheim
 
-ARG RUBY_VERSION=3.3.9
-
 RUN set -eux; \
     apk add --no-cache \
         python3 \
@@ -13,17 +11,9 @@ RUN set -eux; \
         openssl-dev \
         readline-dev \
         yaml-dev \
-        zlib-dev; \
-    mkdir -p /tmp/ruby-build; \
-    cd /tmp/ruby-build; \
-    curl -fSL "https://cache.ruby-lang.org/pub/ruby/${RUBY_VERSION%.*}/ruby-${RUBY_VERSION}.tar.gz" -o ruby.tar.gz; \
-    tar -xzf ruby.tar.gz; \
-    cd ruby-${RUBY_VERSION}; \
-    ./configure --disable-install-doc; \
-    make -j "$(nproc)"; \
-    make install; \
-    cd /; \
-    rm -rf /tmp/ruby-build; \
+        zlib-dev \
+        ruby \
+        ruby-dev; \
     gem update --system --no-document; \
     gem install --no-document bundler:2.6.7
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,31 @@
 FROM lochnesh/exercises-docker:latest
-
 MAINTAINER Skyler Nesheim
 
+ARG RUBY_VERSION=3.3.9
+
 RUN set -eux; \
- apk add --no-cache python3
+    apk add --no-cache \
+        python3 \
+        build-base \
+        curl \
+        git \
+        libffi-dev \
+        openssl-dev \
+        readline-dev \
+        yaml-dev \
+        zlib-dev; \
+    mkdir -p /tmp/ruby-build; \
+    cd /tmp/ruby-build; \
+    curl -fSL "https://cache.ruby-lang.org/pub/ruby/${RUBY_VERSION%.*}/ruby-${RUBY_VERSION}.tar.gz" -o ruby.tar.gz; \
+    tar -xzf ruby.tar.gz; \
+    cd ruby-${RUBY_VERSION}; \
+    ./configure --disable-install-doc; \
+    make -j "$(nproc)"; \
+    make install; \
+    cd /; \
+    rm -rf /tmp/ruby-build; \
+    gem update --system --no-document; \
+    gem install --no-document bundler:2.6.7
 
 COPY ./ /usr/src/exercises
 WORKDIR /usr/src/exercises

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
-gem "aruba", "~> 0.14.2"
-gem 'cucumber', '~> 2.4'
-gem 'json'
+ruby '>= 3.3', '< 4.0'
+
+gem 'aruba', '~> 2.2'
+gem 'cucumber', '~> 9.2'
+gem 'json', '~> 2.7'
+gem 'logger', '~> 1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,48 +1,87 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aruba (0.14.9)
-      childprocess (>= 0.6.3, < 1.1.0)
-      contracts (~> 0.9)
-      cucumber (>= 1.3.19)
-      ffi (~> 1.9)
-      rspec-expectations (>= 2.99)
-      thor (~> 0.19)
-    builder (3.2.3)
-    childprocess (1.0.1)
-      rake (< 13.0)
-    contracts (0.16.0)
-    cucumber (2.99.0)
-      builder (>= 2.1.2)
-      cucumber-core (~> 1.5.0)
-      cucumber-wire (~> 0.0.1)
-      diff-lcs (>= 1.1.3)
-      gherkin (~> 4.0)
-      multi_json (>= 1.7.5, < 2.0)
-      multi_test (>= 0.1.2)
-    cucumber-core (1.5.0)
-      gherkin (~> 4.0)
-    cucumber-wire (0.0.1)
-    diff-lcs (1.3)
-    ffi (1.11.1)
-    gherkin (4.1.3)
-    json (2.3.1)
-    multi_json (1.13.1)
-    multi_test (0.1.2)
-    rake (12.3.3)
-    rspec-expectations (3.8.3)
+    aruba (2.3.2)
+      bundler (>= 1.17, < 3.0)
+      contracts (>= 0.16.0, < 0.18.0)
+      cucumber (>= 8.0, < 11.0)
+      rspec-expectations (>= 3.4, < 5.0)
+      thor (~> 1.0)
+    bigdecimal (3.2.3)
+    builder (3.3.0)
+    contracts (0.17.2)
+    cucumber (9.2.1)
+      builder (~> 3.2)
+      cucumber-ci-environment (> 9, < 11)
+      cucumber-core (> 13, < 14)
+      cucumber-cucumber-expressions (~> 17.0)
+      cucumber-gherkin (> 24, < 28)
+      cucumber-html-formatter (> 20.3, < 22)
+      cucumber-messages (> 19, < 25)
+      diff-lcs (~> 1.5)
+      mini_mime (~> 1.1)
+      multi_test (~> 1.1)
+      sys-uname (~> 1.2)
+    cucumber-ci-environment (10.0.1)
+    cucumber-core (13.0.3)
+      cucumber-gherkin (>= 27, < 28)
+      cucumber-messages (>= 20, < 23)
+      cucumber-tag-expressions (> 5, < 7)
+    cucumber-cucumber-expressions (17.1.0)
+      bigdecimal
+    cucumber-gherkin (27.0.0)
+      cucumber-messages (>= 19.1.4, < 23)
+    cucumber-html-formatter (21.15.1)
+      cucumber-messages (> 19, < 28)
+    cucumber-messages (22.0.0)
+    cucumber-tag-expressions (6.1.2)
+    diff-lcs (1.6.2)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    json (2.15.0)
+    logger (1.7.0)
+    memoist3 (1.0.0)
+    mini_mime (1.1.5)
+    multi_test (1.1.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
-    thor (0.20.3)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.6)
+    sys-uname (1.4.1)
+      ffi (~> 1.1)
+      memoist3 (~> 1.0.0)
+    thor (1.4.0)
 
 PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
   ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
-  aruba (~> 0.14.2)
-  cucumber (~> 2.4)
-  json
+  aruba (~> 2.2)
+  cucumber (~> 9.2)
+  json (~> 2.7)
+  logger (~> 1.6)
+
+RUBY VERSION
+   ruby 3.4.4p34
 
 BUNDLED WITH
-   2.1.4
+   2.6.7


### PR DESCRIPTION
## Summary
- update the Gemfile to target modern releases of aruba, cucumber, json, and add the standalone logger gem
- regenerate the lockfile with Ruby 3.4.4 and Bundler 2.6.7 metadata so the Cucumber suite can install on current Ruby versions
- build Ruby 3.3.9 and Bundler 2.6.7 in the Dockerfile so CI runs against the refreshed toolchain

## Testing
- bundle exec cucumber *(fails: exercise executables are not present in PATH in this environment)*
- ./verify.sh *(fails: `mix local.hex` cannot download metadata from https://builds.hex.pm because it returns HTTP 503)*

------
https://chatgpt.com/codex/tasks/task_b_68d5afdbcd348321ade487ed88e84444